### PR TITLE
[FEATURE] Save checkout id to a cookie

### DIFF
--- a/ember-js-buy/app/adapters/application.js
+++ b/ember-js-buy/app/adapters/application.js
@@ -1,0 +1,5 @@
+import LSAdapter from 'ember-localstorage-adapter';
+
+export default LSAdapter.extend({
+  namespace: 'ember-js-buy'
+});

--- a/ember-js-buy/app/models/cart.js
+++ b/ember-js-buy/app/models/cart.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  checkoutId: DS.attr()
+});

--- a/ember-js-buy/app/serializers/application.js
+++ b/ember-js-buy/app/serializers/application.js
@@ -1,0 +1,3 @@
+import { LSSerializer } from 'ember-localstorage-adapter';
+
+export default LSSerializer.extend();

--- a/ember-js-buy/package.json
+++ b/ember-js-buy/package.json
@@ -33,11 +33,12 @@
     "ember-data": "^2.12.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
+    "ember-localstorage-adapter": "^1.0.0",
     "ember-resolver": "^2.0.3",
     "ember-source": "~2.12.0",
     "ember-welcome-page": "^2.0.2",
     "loader.js": "^4.2.3",
-    "shopify-buy": "alpha"
+    "shopify-buy": "1.0.0-alpha.5"
   },
   "engines": {
     "node": ">= 4"

--- a/ember-js-buy/tests/unit/adapters/application-test.js
+++ b/ember-js-buy/tests/unit/adapters/application-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:application', 'Unit | Adapter | application', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/ember-js-buy/tests/unit/models/cart-test.js
+++ b/ember-js-buy/tests/unit/models/cart-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('cart', 'Unit | Model | cart', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/ember-js-buy/tests/unit/serializers/application-test.js
+++ b/ember-js-buy/tests/unit/serializers/application-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('application', 'Unit | Serializer | application', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:application']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/ember-js-buy/yarn.lock
+++ b/ember-js-buy/yarn.lock
@@ -2512,6 +2512,13 @@ ember-load-initializers@^0.6.0:
   dependencies:
     ember-cli-babel "^5.1.6"
 
+ember-localstorage-adapter@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-localstorage-adapter/-/ember-localstorage-adapter-1.0.0.tgz#985daadce0c149d0afd904a17ef67ae59a0b7e3d"
+  dependencies:
+    ember-cli-babel "^5.1.6"
+    ember-runtime-enumerable-includes-polyfill "^1.0.1"
+
 ember-qunit@^2.0.0-beta.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-2.1.0.tgz#42caad88f477455f99e7cba1cde568967fa74046"
@@ -2531,7 +2538,7 @@ ember-router-generator@^1.0.0:
   dependencies:
     recast "^0.11.3"
 
-ember-runtime-enumerable-includes-polyfill@^1.0.0:
+ember-runtime-enumerable-includes-polyfill@^1.0.0, ember-runtime-enumerable-includes-polyfill@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/ember-runtime-enumerable-includes-polyfill/-/ember-runtime-enumerable-includes-polyfill-1.0.4.tgz#16a7612e347a2edf07da8b2f2f09dbfee70deba0"
   dependencies:
@@ -5407,7 +5414,7 @@ shellwords@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.0.tgz#66afd47b6a12932d9071cbfd98a52e785cd0ba14"
 
-shopify-buy@alpha:
+shopify-buy@1.0.0-alpha.5:
   version "1.0.0-alpha.5"
   resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-1.0.0-alpha.5.tgz#a80f18312ea86f528504db5bcf7f6077e3cf7fc6"
 


### PR DESCRIPTION
Saves `checkoutId` to a cookie. If users want to generate a new cart, they'll have to delete the cookie.

I'll add the same to the other ember examples if this looks okay. @swalkinshaw could you take a quick look since I'm not too familiar with ember-data?