### PR TITLE
Add ability to remove line items to react examples

### DIFF
--- a/ember-apollo/app/templates/components/shopify-cart.hbs
+++ b/ember-apollo/app/templates/components/shopify-cart.hbs
@@ -29,9 +29,7 @@
           <span class="Line-item__price">
             $ {{total-price item.node.variant.price item.node.quantity}}
           </span>
-        </div>
-        <div class="Line-item__content-row">
-          <button class="Line-item__remove" {{action "removeItem" item.node.id}}>Remove Item</button>
+          <button class="Line-item__remove" {{action "removeItem" item.node.id}}>×</button>
         </div>
       </div>
     </li>

--- a/ember-graphql-client/app/templates/components/shopify-cart.hbs
+++ b/ember-graphql-client/app/templates/components/shopify-cart.hbs
@@ -29,9 +29,7 @@
           <span class="Line-item__price">
             $ {{total-price item.variant.price item.quantity}}
           </span>
-        </div>
-        <div class="Line-item__content-row">
-          <button class="Line-item__remove" {{action "removeItem" item.id}}>Remove Item</button>
+          <button class="Line-item__remove" {{action "removeItem" item.id}}>×</button>
         </div>
       </div>
     </li>

--- a/ember-js-buy/app/templates/components/shopify-cart.hbs
+++ b/ember-js-buy/app/templates/components/shopify-cart.hbs
@@ -29,9 +29,7 @@
           <span class="Line-item__price">
             $ {{total-price item.variant.price item.quantity}}
           </span>
-        </div>
-        <div class="Line-item__content-row">
-          <button class="Line-item__remove" {{action "removeItem" item.id}}>Remove Item</button>
+          <button class="Line-item__remove" {{action "removeItem" item.id}}>×</button>
         </div>
       </div>
     </li>

--- a/node-graphql-client/views/index.pug
+++ b/node-graphql-client/views/index.pug
@@ -60,10 +60,9 @@ html(lang='en', data-framework='javascript')
                       input(type='hidden' name='currentQuantity' value=item.quantity)
                       button.Line-item__quantity-update(type='submit') +
                   span.Line-item__price=`$ ${(item.variant.price * item.quantity).toFixed(2)}`
-                .Line-item__content-row
                   form(method='post' action='/remove_line_item/' + item.id.substring(item.id.lastIndexOf('/')))
                     input(type='hidden' name='checkoutId' value=cart.id)
-                    button.Line-teim__remove(type='submit') Remove Item
+                    button.Line-item__remove(type='submit') ×
         footer.Cart__footer
           .Cart-info.clearfix
             .Cart-info__total.Cart-info__small Subtotal

--- a/node-js-buy/views/index.pug
+++ b/node-js-buy/views/index.pug
@@ -57,10 +57,9 @@ html(lang='en', data-framework='javascript')
                       input(type='hidden' name='currentQuantity' value=item.quantity)
                       button.Line-item__quantity-update(type='submit') +
                   span.Line-item__price=`$ ${(item.variant.price * item.quantity).toFixed(2)}`
-                .Line-item__content-row
                   form(method='post' action='/remove_line_item/' + item.id)
                     input(type='hidden' name='checkoutId' value=cart.id)
-                    button.Line-teim__remove(type='submit') Remove Item
+                    button.Line-item__remove(type='submit') ×
         footer.Cart__footer
           .Cart-info.clearfix
             .Cart-info__total.Cart-info__small Subtotal

--- a/react-apollo/src/App.js
+++ b/react-apollo/src/App.js
@@ -8,9 +8,11 @@ import {
   createCheckout,
   checkoutLineItemsAdd,
   checkoutLineItemsUpdate,
+  checkoutLineItemsRemove,
   checkoutCustomerAssociate,
   addVariantToCart,
   updateLineItemInCart,
+  removeLineItemInCart,
   associateCustomerCheckout
 } from './checkout'
 
@@ -32,6 +34,7 @@ class App extends Component {
     this.closeCustomerAuth = this.closeCustomerAuth.bind(this);
     this.addVariantToCart = addVariantToCart.bind(this);
     this.updateLineItemInCart = updateLineItemInCart.bind(this);
+    this.removeLineItemInCart = removeLineItemInCart.bind(this);
     this.showAccountVerificationMessage = this.showAccountVerificationMessage.bind(this);
     this.associateCustomerCheckout = associateCustomerCheckout.bind(this);
   }
@@ -142,7 +145,7 @@ class App extends Component {
           )}
         </div>
         <Cart
-          removeLineItemFromCart={this.removeLineItemFromCart}
+          removeLineItemInCart={this.removeLineItemInCart}
           updateLineItemInCart={this.updateLineItemInCart}
           checkout={this.state.checkout}
           isCartOpen={this.state.isCartOpen}
@@ -216,6 +219,7 @@ const AppWithDataAndMutation = compose(
   graphql(createCheckout, {name: "createCheckout"}),
   graphql(checkoutLineItemsAdd, {name: "checkoutLineItemsAdd"}),
   graphql(checkoutLineItemsUpdate, {name: "checkoutLineItemsUpdate"}),
+  graphql(checkoutLineItemsRemove, {name: "checkoutLineItemsRemove"}),
   graphql(checkoutCustomerAssociate, {name: "checkoutCustomerAssociate"})
 )(App);
 

--- a/react-apollo/src/checkout.js
+++ b/react-apollo/src/checkout.js
@@ -72,6 +72,21 @@ export const checkoutLineItemsUpdate = gql`
   ${CheckoutFragment}
 `;
 
+export const checkoutLineItemsRemove = gql`
+  mutation ($checkoutId: ID!, $lineItemIds: [ID!]!) {
+    checkoutLineItemsRemove(checkoutId: $checkoutId, lineItemIds: $lineItemIds) {
+      userErrors {
+        message
+        field
+      }
+      checkout {
+        ...CheckoutFragment
+      }
+    }
+  }
+  ${CheckoutFragment}
+`;
+
 export const checkoutCustomerAssociate = gql`
   mutation checkoutCustomerAssociate($checkoutId: ID!, $customerAccessToken: String!) {
     checkoutCustomerAssociate(checkoutId: $checkoutId, customerAccessToken: $customerAccessToken) {
@@ -105,6 +120,16 @@ export function updateLineItemInCart(lineItemId, quantity){
     }).then((res) => {
     this.setState({
       checkout: res.data.checkoutLineItemsUpdate.checkout
+    });
+  });
+}
+
+export function removeLineItemInCart(lineItemId){
+  this.props.checkoutLineItemsRemove(
+    { variables: { checkoutId: this.state.checkout.id, lineItemIds: [lineItemId] }
+    }).then((res) => {
+    this.setState({
+      checkout: res.data.checkoutLineItemsRemove.checkout
     });
   });
 }

--- a/react-apollo/src/components/Cart.js
+++ b/react-apollo/src/components/Cart.js
@@ -16,7 +16,7 @@ class Cart extends Component {
     let line_items = this.props.checkout.lineItems.edges.map((line_item) => {
       return (
         <LineItem
-          removeLineItemFromCart={this.props.removeLineItemFromCart}
+          removeLineItemInCart={this.props.removeLineItemInCart}
           updateLineItemInCart={this.props.updateLineItemInCart}
           key={line_item.node.id.toString()}
           line_item={line_item.node}

--- a/react-apollo/src/components/LineItem.js
+++ b/react-apollo/src/components/LineItem.js
@@ -28,8 +28,7 @@ class LineItem extends Component {
               {this.props.line_item.variant.title}
             </div>
             <span className="Line-item__title">
-            {this.props.line_item.quantity} -
-            {this.props.line_item.title}
+              {this.props.line_item.title}
             </span>
           </div>
           <div className="Line-item__content-row">
@@ -41,6 +40,7 @@ class LineItem extends Component {
             <span className="Line-item__price">
               $ { (this.props.line_item.quantity * this.props.line_item.variant.price).toFixed(2) }
             </span>
+            <button className="Line-item__remove" onClick={()=> this.props.removeLineItemInCart(this.props.line_item.id)}>×</button>
           </div>
         </div>
       </li>

--- a/react-graphql-client/src/components/Cart.js
+++ b/react-graphql-client/src/components/Cart.js
@@ -17,6 +17,7 @@ class Cart extends Component {
       return (
         <LineItem
           updateQuantityInCart={this.props.updateQuantityInCart}
+          removeLineItemInCart={this.props.removeLineItemInCart}
           key={line_item.id.toString()}
           line_item={line_item}
         />

--- a/react-graphql-client/src/components/LineItem.js
+++ b/react-graphql-client/src/components/LineItem.js
@@ -30,8 +30,7 @@ class LineItem extends Component {
               {this.props.line_item.variant.title}
             </div>
             <span className="Line-item__title">
-            {this.props.line_item.quantity} -
-            {this.props.line_item.title}
+              {this.props.line_item.title}
             </span>
           </div>
           <div className="Line-item__content-row">
@@ -43,6 +42,7 @@ class LineItem extends Component {
             <span className="Line-item__price">
               $ { (this.props.line_item.quantity * this.props.line_item.variant.price).toFixed(2) }
             </span>
+            <button className="Line-item__remove" onClick={()=> this.props.removeLineItemInCart(this.props.line_item.id)}>×</button>
           </div>
         </div>
       </li>

--- a/react-js-buy/src/App.js
+++ b/react-js-buy/src/App.js
@@ -15,6 +15,7 @@ class App extends Component {
     this.handleCartClose = this.handleCartClose.bind(this);
     this.addVariantToCart = this.addVariantToCart.bind(this);
     this.updateQuantityInCart = this.updateQuantityInCart.bind(this);
+    this.removeLineItemInCart = this.removeLineItemInCart.bind(this);
   }
 
   componentWillMount() {
@@ -60,6 +61,16 @@ class App extends Component {
     });
   }
 
+  removeLineItemInCart(lineItemId) {
+    const checkoutId = this.state.checkout.id
+
+    return this.props.client.removeLineItems(checkoutId, [lineItemId]).then(res => {
+      this.setState({
+        checkout: res,
+      });
+    });
+  }
+
   handleCartClose() {
     this.setState({
       isCartOpen: false,
@@ -89,6 +100,7 @@ class App extends Component {
           isCartOpen={this.state.isCartOpen}
           handleCartClose={this.handleCartClose}
           updateQuantityInCart={this.updateQuantityInCart}
+          removeLineItemInCart={this.removeLineItemInCart}
         />
       </div>
     );

--- a/react-js-buy/src/components/Cart.js
+++ b/react-js-buy/src/components/Cart.js
@@ -17,6 +17,7 @@ class Cart extends Component {
       return (
         <LineItem
           updateQuantityInCart={this.props.updateQuantityInCart}
+          removeLineItemInCart={this.props.removeLineItemInCart}
           key={line_item.id.toString()}
           line_item={line_item}
         />

--- a/react-js-buy/src/components/LineItem.js
+++ b/react-js-buy/src/components/LineItem.js
@@ -30,8 +30,7 @@ class LineItem extends Component {
               {this.props.line_item.variant.title}
             </div>
             <span className="Line-item__title">
-            {this.props.line_item.quantity} -
-            {this.props.line_item.title}
+              {this.props.line_item.title}
             </span>
           </div>
           <div className="Line-item__content-row">
@@ -43,6 +42,7 @@ class LineItem extends Component {
             <span className="Line-item__price">
               $ { (this.props.line_item.quantity * this.props.line_item.variant.price).toFixed(2) }
             </span>
+            <button className="Line-item__remove" onClick={()=> this.props.removeLineItemInCart(this.props.line_item.id)}>×</button>
           </div>
         </div>
       </li>

--- a/shared/app.css
+++ b/shared/app.css
@@ -211,6 +211,7 @@ h2 {
   display: inline-block;
   width: 100%;
   margin-bottom: 5px;
+  position: relative;
 }
 
 .Line-item__variant-title {
@@ -232,6 +233,7 @@ h2 {
   float: right;
   font-weight: bold;
   font-size: 15px;
+  margin-right: 40px;
 }
 
 .Line-item__quantity-container {
@@ -277,6 +279,22 @@ h2 {
   float: left;
   padding: 0;
   border-radius: 0;
+}
+
+.Line-item__remove {
+  position: absolute;
+  right: 0;
+  top: 0;
+  border: 0;
+  background: 0;
+  font-size: 20px;
+  top: -4px;
+  opacity: 0.5;
+}
+
+.Line-item__remove:hover {
+  opacity: 1;
+  cursor: pointer;
 }
 
 /* PRODUCTS


### PR DESCRIPTION
- Add the remove line item mutation to react examples since they were missing before.
- Updated CSS for the remove button and fixed some of the markup for the other examples.