### PR TITLE
Remove old cart button from Node GraphQL Client example.

### DIFF
--- a/node-graphql-client/views/index.pug
+++ b/node-graphql-client/views/index.pug
@@ -32,9 +32,6 @@ html(lang='en', data-framework='javascript')
               button.Product__buy.button#add-to-cart-button(type='submit')
                   | Add to cart
 
-      .view-cart-wrapper
-        button.view-cart#view-cart-button Cart
-
       .Cart#cart(class={'Cart--open': isCartOpen})
         header.Cart__header
           h2 Cart


### PR DESCRIPTION
Hi, it seems like this cart button was intended to be removed in this commit: 51c9b1d.

I noticed the extra button while running the example at the bottom of the page.

Thanks, these are great examples.

FYI @jzjiang 