### PR TITLE
fix #54 where product state is not set properly

### DIFF
--- a/react-js-buy/src/components/Product.js
+++ b/react-js-buy/src/components/Product.js
@@ -13,10 +13,12 @@ class Product extends Component {
   }
 
   componentWillMount() {
+    let defaultOptionValues = {};
     this.props.product.options.forEach((selector) => {
-      this.setState({
-        selectedOptions: { [selector.name]: selector.values[0].value }
-      });
+      defaultOptionValues[selector.name] = selector.values[0].value;
+    });
+    this.setState({
+      selectedOptions: defaultOptionValues
     });
   }
 


### PR DESCRIPTION
The product component assigned initial default values into state using a forEach method in componentWillMount and in it calling setState. 
As best I can understand or explain it, setState can act asynchronously at times, and by calling it with a forEach loop it was overriding or dropping key/value pairs. 