### PR TITLE
Keep consistency in Ember usage

### DIFF
--- a/ember-js-buy/app/services/cart.js
+++ b/ember-js-buy/app/services/cart.js
@@ -1,14 +1,12 @@
-import Ember from 'ember';
-
-const { Service, inject } = Ember;
+import Service, { inject as service } from '@ember/service';
 
 export default Service.extend({
-  store: Ember.inject.service('store'),
-  client: inject.service('js-buy-sdk-client'),
+  store: service('store'),
+  client: service('js-buy-sdk-client'),
   checkout: null,
 
   init() {
-    return this.get('store').findAll('cart').then((result) => {
+    return this.get('store').findAll('cart').then(result => {
       const cartRecord = result.get('lastObject');
 
       if (cartRecord) {


### PR DESCRIPTION
- Remove direct reference to the entire Ember object, inject Service only
- Remove reference to `Ember.inject.service()` and `inject.service` to use `service()`
- Keep consistent code styling by removing brackets on arrow function params