### PR TITLE
remove unused checkout prop in Products>Product

### DIFF
--- a/react-js-buy/src/components/Products.js
+++ b/react-js-buy/src/components/Products.js
@@ -8,7 +8,6 @@ class Products extends Component {
         <Product
           addVariantToCart={this.props.addVariantToCart}
           client={this.props.client}
-          checkout={this.props.checkout}
           key={product.id.toString()}
           product={product}
         />


### PR DESCRIPTION
I'd like to add propTypes to the react-js-buy example and in doing so I believe I've found that this prop is superfluous. 