### PR TITLE
Fix README install instructions

### DIFF
--- a/react-js-buy/README.md
+++ b/react-js-buy/README.md
@@ -14,7 +14,7 @@ You will need the following things properly installed on your computer.
 
 * `git clone https://github.com/Shopify/storefront-api-examples.git` this repository
 * `cd storefront-api-examples`
-* `cd react-js-buy-sdk`
+* `cd react-js-buy`
 * `yarn install`
 
 ## Configuring


### PR DESCRIPTION
The install instructions currently say `cd react-js-buy-sdk`. This is the incorrect path for this example. This pull request updates the instructions to `cd react-js-buy`.