### PR TITLE
Update Cart.js checkout button

### DIFF
--- a/react-js-buy/src/components/Cart.js
+++ b/react-js-buy/src/components/Cart.js
@@ -56,7 +56,22 @@ class Cart extends Component {
               <span className="pricing">$ {this.props.checkout.totalPrice}</span>
             </div>
           </div>
-          <button className="Cart__checkout button" onClick={this.openCheckout}>Checkout</button>
+            {line_items.length >= 1 ? (
+            <button
+              className="Cart__checkout button"
+              onClick={this.openCheckout}
+            >
+              Checkout
+            </button>
+          ) : (
+            <button
+              className="Cart__checkout button"
+              onClick={this.openCheckout}
+              disabled
+            >
+              Checkout
+            </button>
+          )}
         </footer>
       </div>
     )


### PR DESCRIPTION
Previously, the checkout button was always enabled, even if there were no items in the cart. The added code conditionally renders the button as either disabled or enabled, so when there are no items in the cart it will not be able to be clicked.